### PR TITLE
Fix test spec expansion

### DIFF
--- a/qpm/cli/controllers/sclang.py
+++ b/qpm/cli/controllers/sclang.py
@@ -112,6 +112,7 @@ class SCLang_RunTest(SCLang_AbstractBase):
 
 			except Exception, e:
 				self.app.render(e, 'error')
+				self.app.close(1)
 
 def generate_summary(test_plan, duration):
 	total = 0

--- a/qpm/scscripts/test_runner.scd
+++ b/qpm/scscripts/test_runner.scd
@@ -17,6 +17,7 @@
 ~testrun = {
 	| file |
 	var test_record, test_record_string;
+
 	try {
 		test_record_string = File(file, "r").readAllString();
 	} { |err|
@@ -24,9 +25,13 @@
 	};
 
 	try {
-		var tests, skipped, settings, toExpand, toExclude, starStarTests;
 		test_record = test_record_string.parseYAML();
+	} { |err|
+		Error("testrun: Could not parse input file: %".format(err.what)).throw;
+	};
 
+	try {
+		var tests, skipped, settings, toExpand, toExclude, starStarTests;
 		UnitTest.findTestClasses();
 
 		if (test_record["tests"].isEmpty) {

--- a/qpm/scscripts/test_runner.scd
+++ b/qpm/scscripts/test_runner.scd
@@ -40,8 +40,8 @@
 
 	if (suiteGlob.notEmpty) {
 		var all = UnitTest.allTestClasses.keys.select({ |t| t != "...All..." }).asArray.collect({
-			|classSym|
-			Dictionary.newFrom(("suite": classSym.asSymbol.asClass.asString, "test": "*"))
+			|className|
+			Dictionary.newFrom(("suite": "Test" ++ className, "test": "*"))
 		});
 		testsDict.removeAll(suiteGlob);
 		testsDict = all ++ testsDict;

--- a/qpm/scscripts/test_runner.scd
+++ b/qpm/scscripts/test_runner.scd
@@ -30,13 +30,13 @@
 		Error("testrun: Could not parse input file: %".format(err.what)).throw;
 	};
 
+	if (test_record["tests"].isEmpty) {
+		Error("testrun: No tests defined").throw;
+	};
+
 	try {
 		var tests, skipped, settings, toExpand, toExclude, starStarTests;
 		UnitTest.findTestClasses();
-
-		if (test_record["tests"].isEmpty) {
-			Error("No tests defined").throw;
-		};
 
 		starStarTests = test_record["tests"].select({
 			|item|

--- a/qpm/scscripts/test_runner.scd
+++ b/qpm/scscripts/test_runner.scd
@@ -194,7 +194,11 @@
 
 
 {
-	~testrun.(~testRecord);
+	try {
+		~testrun.(~testRecord);
+	} { |err|
+		err.what.error;
+	};
 	"******** DONE ********".postln;
 	0.exit;
 }.forkIfNeeded(AppClock);

--- a/qpm/scscripts/test_runner.scd
+++ b/qpm/scscripts/test_runner.scd
@@ -22,13 +22,13 @@
 	try {
 		test_record_string = File(file, "r").readAllString();
 	} { |err|
-		Error("testrun: Could not read input file %: %".format(file, err.what)).throw;
+		Error("getTestRecord: Could not read input file %: %".format(file, err.what)).throw;
 	};
 
 	try {
 		test_record = test_record_string.parseYAML();
 	} { |err|
-		Error("testrun: Could not parse input file: %".format(err.what)).throw;
+		Error("getTestRecord: Could not parse input file: %".format(err.what)).throw;
 	};
 
 	test_record;

--- a/qpm/scscripts/test_runner.scd
+++ b/qpm/scscripts/test_runner.scd
@@ -14,8 +14,9 @@
 	file.close();
 };
 
-~testrun = {
-	| file |
+// safely extract the test record dictionary from the input file
+~getTestRecord = {
+	|file|
 	var test_record, test_record_string;
 
 	try {
@@ -29,6 +30,14 @@
 	} { |err|
 		Error("testrun: Could not parse input file: %".format(err.what)).throw;
 	};
+
+	test_record;
+};
+
+~testrun = {
+	| file |
+
+	var test_record = ~getTestRecord.(file);
 
 	if (test_record["tests"].isEmpty) {
 		Error("testrun: No tests defined").throw;

--- a/qpm/scscripts/test_runner.scd
+++ b/qpm/scscripts/test_runner.scd
@@ -34,6 +34,22 @@
 	test_record;
 };
 
+// expand { suite: * } to a dictionary of { test: * } records
+~expandSuiteGlob = { |testsDict|
+	var suiteGlob = testsDict.select { |item| item["suite"] == "*" };
+
+	if (suiteGlob.notEmpty) {
+		var all = UnitTest.allTestClasses.keys.select({ |t| t != "...All..." }).asArray.collect({
+			|classSym|
+			Dictionary.newFrom(("suite": classSym.asSymbol.asClass.asString, "test": "*"))
+		});
+		testsDict.removeAll(suiteGlob);
+		testsDict = all ++ testsDict;
+	};
+
+	testsDict;
+};
+
 ~testrun = {
 	| file |
 
@@ -47,19 +63,7 @@
 		var tests, skipped, settings, toExpand, toExclude, starStarTests;
 		UnitTest.findTestClasses();
 
-		starStarTests = test_record["tests"].select({
-			|item|
-			item["suite"] == "*"
-		});
-		test_record["tests"].removeAll(starStarTests);
-
-		if (starStarTests.notEmpty) {
-			var all = UnitTest.allTestClasses.keys.select({ |t| t != "...All..." }).asArray.collect({
-				|classSym|
-				Dictionary.newFrom(("suite": classSym.asSymbol.asClass.asString, "test": "*"))
-			});
-			test_record["tests"] = all ++ test_record["tests"]
-		};
+		test_record["tests"] = ~expandSuiteGlob.(test_record["tests"]);
 
 		test_record["tests"] = List.newFrom(test_record["tests"].collect(Dictionary.newFrom(_)));
 

--- a/qpm/scscripts/test_runner.scd
+++ b/qpm/scscripts/test_runner.scd
@@ -25,7 +25,7 @@
 		UnitTest.findTestClasses();
 
 		if (test_record["tests"].isEmpty) {
-			"No tests defined".throw;
+			Error("No tests defined").throw;
 		};
 
 		starStarTests = test_record["tests"].select({

--- a/qpm/scscripts/test_runner.scd
+++ b/qpm/scscripts/test_runner.scd
@@ -60,7 +60,7 @@
 	};
 
 	try {
-		var tests, skipped, settings, toExpand, toExclude, starStarTests;
+		var tests, skipped, settings, toExpand, toExclude;
 		UnitTest.findTestClasses();
 
 		test_record["tests"] = ~expandSuiteGlob.(test_record["tests"]);

--- a/qpm/scscripts/test_runner.scd
+++ b/qpm/scscripts/test_runner.scd
@@ -17,7 +17,12 @@
 ~testrun = {
 	| file |
 	var test_record, test_record_string;
-	test_record_string = File(file, "r").readAllString();
+	try {
+		test_record_string = File(file, "r").readAllString();
+	} { |err|
+		Error("testrun: Could not read input file %: %".format(file, err.what)).throw;
+	};
+
 	try {
 		var tests, skipped, settings, toExpand, toExclude, starStarTests;
 		test_record = test_record_string.parseYAML();


### PR DESCRIPTION
This PR improves `test_runner.scd` by fixing the way `{ "suite": "*" }` is expanded is the JSON test runner spec (see c2e4664).

Also factors out some small bits. I just did that while I was trying to understand the code and think it reads a little better this way.